### PR TITLE
Added timeout option for mutex behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ class HelloController extends Controller
             'mutexBehavior' => [
                 'class' => 'yii2mod\cron\behaviors\MutexConsoleCommandBehavior',
                 'mutexActions' => ['index'],
+                'timeout' => 3600, //default 0
             ]
         ];
     }

--- a/behaviors/MutexConsoleCommandBehavior.php
+++ b/behaviors/MutexConsoleCommandBehavior.php
@@ -43,6 +43,12 @@ class MutexConsoleCommandBehavior extends Behavior
     public $mutexActions = [];
 
     /**
+     * @var int time (in seconds) to wait for lock to be released. Defaults to zero meaning that method will return
+     * false immediately in case lock was already acquired.
+     */
+    public $timeout = 0;
+
+    /**
      * @inheritdoc
      */
     public function events()
@@ -94,7 +100,7 @@ class MutexConsoleCommandBehavior extends Behavior
     {
         if ($this->checkIsMutexAction($event->action->id)) {
             $mutexName = $this->composeMutexName($event->action->id);
-            if (!$this->getMutex()->acquire($mutexName)) {
+            if (!$this->getMutex()->acquire($mutexName, $this->timeout)) {
                 echo "Execution terminated: command is already running.\n";
                 $event->isValid = false;
 


### PR DESCRIPTION
I often have a locked command for a few days, it's hard to handle the error of this. Timeout solves the problem.